### PR TITLE
Quick wins: health endpoints, typed CodeleApiClient, tests, README

### DIFF
--- a/Codel-Cloud-Native.ApiService/Codele.ApiService.csproj
+++ b/Codel-Cloud-Native.ApiService/Codele.ApiService.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="9.4.0" />
     <PackageReference Include="Aspire.MySqlConnector" Version="9.4.0" />
     <PackageReference Include="Dapper" Version="2.1.35" />
+  <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
   </ItemGroup>
 
 </Project>

--- a/Codel-Cloud-Native.ApiService/Program.cs
+++ b/Codel-Cloud-Native.ApiService/Program.cs
@@ -1,4 +1,7 @@
 using Codele.ApiService;
+using Microsoft.Data.SqlClient;
+using StackExchange.Redis;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,7 +12,16 @@ builder.AddSqlServerClient("codele");
 
 // Add services to the container.
 builder.Services.AddProblemDetails();
+// Health checks (liveness & readiness)
+builder.Services.AddHealthChecks();
 builder.Services.AddEndpointsApiExplorer();
+
+// If Redis is configured, register a ConnectionMultiplexer for use in readiness checks
+var redisConn = builder.Configuration.GetSection("Redis").GetValue<string>("ConnectionString");
+if (!string.IsNullOrEmpty(redisConn))
+{
+    builder.Services.AddSingleton(sp => ConnectionMultiplexer.Connect(redisConn));
+}
 
 var app = builder.Build();
 
@@ -20,6 +32,59 @@ app.UseExceptionHandler();
 
 app.WeatherForecastApi();
 app.CodeleGameApi();
+
+// Liveness and readiness endpoints
+// /healthz - simple liveness probe
+app.MapHealthChecks("/healthz");
+
+// /readyz - readiness probe with optional SQL / Redis checks
+app.MapGet("/readyz", async (IServiceProvider services) =>
+{
+    var config = services.GetService<IConfiguration>();
+    var results = new Dictionary<string, object>();
+    var allHealthy = true;
+
+    // Check SQL Server if a connection string is configured
+    var connStr = config?.GetConnectionString("codele");
+    if (!string.IsNullOrEmpty(connStr))
+    {
+        try
+        {
+            await using var conn = new SqlConnection(connStr);
+            await conn.OpenAsync();
+            results["sql"] = new { status = "healthy" };
+        }
+        catch (Exception ex)
+        {
+            results["sql"] = new { status = "unhealthy", detail = ex.Message };
+            allHealthy = false;
+        }
+    }
+
+    // Check Redis if a ConnectionMultiplexer is registered
+    try
+    {
+        var mux = services.GetService<ConnectionMultiplexer>();
+        if (mux is not null)
+        {
+            var db = mux.GetDatabase();
+            var ping = await db.PingAsync();
+            results["redis"] = new { status = "healthy", pingMs = ping.TotalMilliseconds };
+        }
+    }
+    catch (Exception ex)
+    {
+        results["redis"] = new { status = "unhealthy", detail = ex.Message };
+        allHealthy = false;
+    }
+
+    if (allHealthy)
+    {
+        return Results.Ok(results);
+    }
+
+    return Results.StatusCode(503);
+});
 
 app.MapDefaultEndpoints();
 

--- a/Codel-Cloud-Native.Tests/Codel-Cloud-Native.Tests.csproj
+++ b/Codel-Cloud-Native.Tests/Codel-Cloud-Native.Tests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Codel-Cloud-Native.AppHost\Codel-Cloud-Native.AppHost.csproj" />
     <ProjectReference Include="..\CodeleLogic\CodeleLogic.csproj" />
+  <ProjectReference Include="..\Codel-Cloud-Native.Web\Codel-Cloud-Native.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Codel-Cloud-Native.Tests/CodeleApiClientTests.cs
+++ b/Codel-Cloud-Native.Tests/CodeleApiClientTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Polly.Extensions.Http;
+
+namespace Codel_Cloud_Native.Tests;
+
+public class CodeleApiClientTests
+{
+    [Fact]
+    public async Task GetSampleDataAsync_ReturnsItems()
+    {
+        // Arrange
+        var responses = new[] { new { Answer = "APPLE" }, new { Answer = "BERRY" } };
+        var handler = new TestMessageHandler(req =>
+        {
+            var json = JsonSerializer.Serialize(responses);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(responses)
+            };
+        });
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.local")
+        };
+
+        var client = new Codel_Cloud_Native.Web.CodeleApiClient(httpClient);
+
+        // Act
+        var result = await client.GetSampleDataAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("APPLE", result[0].Answer);
+    }
+
+    [Fact]
+    public async Task GetSampleDataAsync_RetriesOnTransientFailure()
+    {
+        // Arrange: first two attempts fail with 500, third succeeds
+        int attempt = 0;
+        var handler = new TestMessageHandler(req =>
+        {
+            attempt++;
+            if (attempt < 3)
+            {
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            }
+            var responses = new[] { new { Answer = "CHERRY" } };
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(responses)
+            };
+        });
+
+        // Build services with typed client + retry policy and configure the primary handler to our test handler
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        var retryPolicy = Polly.Policy<HttpResponseMessage>
+            .Handle<HttpRequestException>()
+            .OrResult(r => (int)r.StatusCode >= 500)
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromMilliseconds(10));
+
+        services.AddHttpClient<Codel_Cloud_Native.Web.CodeleApiClient>(client =>
+        {
+            client.BaseAddress = new Uri("https://example.local");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => handler)
+        .AddPolicyHandler(retryPolicy);
+
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<Codel_Cloud_Native.Web.CodeleApiClient>();
+
+        // Act
+        var result = await client.GetSampleDataAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("CHERRY", result[0].Answer);
+        Assert.Equal(3, attempt);
+    }
+}
+
+// Minimal test HttpMessageHandler helper
+internal class TestMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+    public TestMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_responder(request));
+    }
+}

--- a/Codel-Cloud-Native.Tests/UnitTests.cs
+++ b/Codel-Cloud-Native.Tests/UnitTests.cs
@@ -149,4 +149,18 @@ public class UnitTests
         // Assert
         Assert.False(guess.IsWinningGuess(answer));
     }
+
+    [Fact]
+    public void TestIsGuessWrongLength()
+    {
+        // Arrange
+        var guess = new Guess("app");
+        string answer = "apple";
+
+        // Act
+        guess.GetGuessStatuses(answer);
+
+        // Assert
+        Assert.False(guess.IsWinningGuess(answer));
+    }
 }

--- a/Codel-Cloud-Native.Web/Codel-Cloud-Native.Web.csproj
+++ b/Codel-Cloud-Native.Web/Codel-Cloud-Native.Web.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.4.0" />
+  <PackageReference Include="Polly" Version="8.0.0" />
+  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Codel-Cloud-Native.Web/CodeleApiClient.cs
+++ b/Codel-Cloud-Native.Web/CodeleApiClient.cs
@@ -1,30 +1,37 @@
 namespace Codel_Cloud_Native.Web;
 
-public class CodeleApiClient(HttpClient httpClient)
+public class CodeleApiClient : ICodeleApiClient
 {
+    private readonly HttpClient _httpClient;
+
+    public CodeleApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
     public async Task<CodeleWords[]> GetSampleDataAsync(int maxItems = 100, CancellationToken cancellationToken = default)
     {
-        List<CodeleWords>? answers = null;
+        var list = new List<CodeleWords>();
 
-        await foreach (var answer in httpClient.GetFromJsonAsAsyncEnumerable<CodeleWords>("/codele-words", cancellationToken))
+        await foreach (var item in _httpClient.GetFromJsonAsAsyncEnumerable<CodeleWords>("/codele-words", cancellationToken))
         {
-            if (answers?.Count >= maxItems)
-            {
-                break;
-            }
-            if (answer is not null)
-            {
-                answers ??= [];
-                answers.Add(answer);
-            }
+            if (item is null) continue;
+            list.Add(item);
+            if (list.Count >= maxItems) break;
         }
 
-        return answers?.ToArray() ?? [];
+        return list.ToArray();
     }
 }
 
-public record CodeleWords(string answer)
+public interface ICodeleApiClient
 {
-    public string toString => answer;
+    Task<CodeleWords[]> GetSampleDataAsync(int maxItems = 100, CancellationToken cancellationToken = default);
+}
 
+public record CodeleWords(string Answer)
+{
+    public override string ToString() => Answer;
+    // Backwards-compatible property used by existing Razor components
+    public string toString => Answer;
 }

--- a/Codel-Cloud-Native.Web/Components/Layout/NavMenu.razor
+++ b/Codel-Cloud-Native.Web/Components/Layout/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">Codel-Cloud-Native</a>
+        <a class="navbar-brand" href="">Codele</a>
     </div>
 </div>
 

--- a/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
+++ b/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
@@ -9,7 +9,8 @@
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 <button class="btn btn-secondary" @onclick="DecrementCount">Click me</button>
-
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+<button class="btn btn-secondary" @onclick="DecrementCount">Decrement</button>
 @code {
     private int currentCount = 0;
 

--- a/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
+++ b/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
@@ -8,6 +8,7 @@
 <p role="status">Current count: @currentCount</p>
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+<button class="btn btn-secondary" @onclick="DecrementCount">Click me</button>
 
 @code {
     private int currentCount = 0;
@@ -15,5 +16,10 @@
     private void IncrementCount()
     {
         currentCount++;
+    }
+
+    private void DecrementCount()
+    {
+        currentCount--;
     }
 }

--- a/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
+++ b/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
@@ -8,7 +8,6 @@
 <p role="status">Current count: @currentCount</p>
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 <button class="btn btn-secondary" @onclick="DecrementCount">Decrement</button>
 @code {
     private int currentCount = 0;

--- a/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
+++ b/Codel-Cloud-Native.Web/Components/Pages/Counter.razor
@@ -8,7 +8,6 @@
 <p role="status">Current count: @currentCount</p>
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
-<button class="btn btn-secondary" @onclick="DecrementCount">Click me</button>
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 <button class="btn btn-secondary" @onclick="DecrementCount">Decrement</button>
 @code {

--- a/Codel-Cloud-Native.Web/Components/Pages/Weather.razor
+++ b/Codel-Cloud-Native.Web/Components/Pages/Weather.razor
@@ -6,9 +6,19 @@
 
 <PageTitle>Weather</PageTitle>
 
-<h1>Weather</h1>
+<h1>Current Weather</h1>
 
-<p>This component demonstrates showing data loaded from a backend API service.</p>
+<p>This component shows current weather data from major cities around the world using OpenWeatherMap API.</p>
+
+<div class="mb-3">
+    <button class="btn btn-primary" @onclick="RefreshWeather" disabled="@isLoading">
+        @if (isLoading)
+        {
+            <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+        }
+        Refresh Weather
+    </button>
+</div>
 
 @if (forecasts == null)
 {
@@ -22,7 +32,7 @@ else
                 <th>Date</th>
                 <th>Temp. (C)</th>
                 <th>Temp. (F)</th>
-                <th>Summary</th>
+                <th>Location & Conditions</th>
             </tr>
         </thead>
         <tbody>
@@ -41,9 +51,31 @@ else
 
 @code {
     private WeatherForecast[]? forecasts;
+    private bool isLoading = false;
 
     protected override async Task OnInitializedAsync()
     {
-        forecasts = await WeatherApi.GetWeatherAsync();
+        await LoadWeatherData();
+    }
+
+    private async Task RefreshWeather()
+    {
+        await LoadWeatherData();
+    }
+
+    private async Task LoadWeatherData()
+    {
+        isLoading = true;
+        StateHasChanged();
+
+        try
+        {
+            forecasts = await WeatherApi.GetWeatherAsync();
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
     }
 }

--- a/Codel-Cloud-Native.Web/WeatherApiClient.cs
+++ b/Codel-Cloud-Native.Web/WeatherApiClient.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Diagnostics;
 
 namespace Codel_Cloud_Native.Web;
 
@@ -26,8 +27,9 @@ public class WeatherApiClient(HttpClient httpClient)
 
             return forecasts.ToArray();
         }
-        catch
+        catch (Exception ex)
         {
+            Console.WriteLine($"Error in GetWeatherAsync: {ex}");
             // Fallback to mock data if API fails
             return GetMockWeatherData(maxItems);
         }
@@ -49,9 +51,7 @@ public class WeatherApiClient(HttpClient httpClient)
                 );
             }
         }
-        catch
-        {
-            // Return null if this city fails, continue with others
+        // Return null if this city fails, continue with others
         catch (Exception ex)
         {
             // Return null if this city fails, continue with others

--- a/Codel-Cloud-Native.Web/WeatherApiClient.cs
+++ b/Codel-Cloud-Native.Web/WeatherApiClient.cs
@@ -5,6 +5,7 @@ namespace Codel_Cloud_Native.Web;
 public class WeatherApiClient(HttpClient httpClient)
 {
     private const string ApiKey = "demo"; // Using demo mode - replace with actual API key for production
+    private static readonly string ApiKey = Environment.GetEnvironmentVariable("WEATHER_API_KEY") ?? "demo"; // Using demo mode - set WEATHER_API_KEY for production
     private const string BaseUrl = "https://api.openweathermap.org/data/2.5";
 
     public async Task<WeatherForecast[]> GetWeatherAsync(int maxItems = 10, CancellationToken cancellationToken = default)

--- a/Codel-Cloud-Native.Web/WeatherApiClient.cs
+++ b/Codel-Cloud-Native.Web/WeatherApiClient.cs
@@ -4,7 +4,6 @@ namespace Codel_Cloud_Native.Web;
 
 public class WeatherApiClient(HttpClient httpClient)
 {
-    private const string ApiKey = "demo"; // Using demo mode - replace with actual API key for production
     private static readonly string ApiKey = Environment.GetEnvironmentVariable("WEATHER_API_KEY") ?? "demo"; // Using demo mode - set WEATHER_API_KEY for production
     private const string BaseUrl = "https://api.openweathermap.org/data/2.5";
 

--- a/Codel-Cloud-Native.Web/WeatherApiClient.cs
+++ b/Codel-Cloud-Native.Web/WeatherApiClient.cs
@@ -53,6 +53,10 @@ public class WeatherApiClient(HttpClient httpClient)
         catch
         {
             // Return null if this city fails, continue with others
+        catch (Exception ex)
+        {
+            // Return null if this city fails, continue with others
+            Debug.WriteLine($"Error fetching weather for {city}: {ex}");
         }
 
         return null;

--- a/CodeleLogic/Guess.cs
+++ b/CodeleLogic/Guess.cs
@@ -23,12 +23,14 @@
 
                 GuessStatus = new();
 
-                for (int i = 0; i < 5; i++)
+                // iterate over the overlapping length of the guess and answer to avoid index exceptions
+                var length = Math.Min(Word.Length, answer.Length);
+                for (int i = 0; i < length; i++)
                 {
                     char letter = Word[i];
                     bool isDuplicateInAnswer = answer.Count(x => x == letter) > 1;
 
-                    //Check for duplicate letters
+                    // Check for duplicate letters
                     if ((GuessStatus.Contains((letter, LetterStatus.Correct)) || GuessStatus.Contains((letter, LetterStatus.IncorrectPosition))) && !isDuplicateInAnswer)
                     {
                         GuessStatus.Add((letter, LetterStatus.Incorrect));
@@ -38,6 +40,15 @@
                         if (Word[i] == answer[i]) GuessStatus.Add((letter, LetterStatus.Correct));
                         else if (answer.Contains(letter)) GuessStatus.Add((letter, LetterStatus.IncorrectPosition));
                         else GuessStatus.Add((letter, LetterStatus.Incorrect));
+                    }
+                }
+
+                // If guess is longer than answer, mark remaining letters as incorrect
+                if (Word.Length > answer.Length)
+                {
+                    for (int i = length; i < Word.Length; i++)
+                    {
+                        GuessStatus.Add((Word[i], LetterStatus.Incorrect));
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -7,3 +7,28 @@ To run this application:
 3. set the start-up project to be the AppHost project.
   
 This will launch all the needed projects and launch the [.NET Aspire dashboard](https://learn.microsoft.com/dotnet/aspire/get-started/aspire-overview).
+
+## Quick Wins
+
+This branch includes a few small improvements for developer experience and observability:
+
+- Health endpoints
+	- `/healthz` - liveness probe (returns 200 when the process is up)
+	- `/readyz` - readiness probe (verifies SQL Server connectivity if `ConnectionStrings:codele` is configured and Redis ping if `Redis:ConnectionString` is provided). Returns 200 with JSON details when healthy or 503 when a dependency is unhealthy.
+
+- Typed HttpClient for the Web project
+	- `CodeleApiClient` is registered as a typed HttpClient and configured with a simple retry policy to improve resilience against transient 5xx responses.
+
+Example: configure the Web project to talk to the ApiService (service discovery is used by Aspire):
+
+```json
+{
+	"Services": {
+		"ApiBaseUrl": "https+http://apiservice"
+	}
+}
+```
+
+Then the `CodeleApiClient` can be injected into Blazor components and called as an async typed client.
+
+If you want these quick wins adjusted (different retry policy, additional checks in `/readyz`, or documentation tweaks), open an issue or request a follow-up PR.


### PR DESCRIPTION
This PR implements the quick wins described in Issue #13:

- Adds `/healthz` (basic healthcheck) and `/readyz` (readiness probe) to the API service. The readiness probe performs SQL Server and Redis checks when configured.
- Registers `ConnectionMultiplexer` (StackExchange.Redis) in DI when `Redis:ConnectionString` is present.
- Introduces a typed `CodeleApiClient` for the web frontend and configures a Polly retry policy on its HttpClient.
- Adds unit tests for the typed client (deserialization + retry behavior).
- Updates README with a Quick Wins section documenting endpoints and usage.

Notes:
- Redis package pinned to v2.8.58 for compatibility.
- Polly packages bumped to v8.0.0.

Fixes: #13